### PR TITLE
Adding instance to AuthOptions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -30,6 +30,11 @@ export interface AuthOptions {
    * The resource to authenticate to. Defaults to environment.resourceManagerEndpointUrl.
    */
   resource?: string;
+
+  /**
+   * The Azure Active Directory Instance. Defaults to `https://login.microsoftonline.com/`.
+   */
+  instance?: string;
 }
 
 export interface Subscription {
@@ -100,8 +105,10 @@ export class AuthManager {
       clientId: opts.clientId,
       tenant: opts.tenant,
       redirectUri: opts.redirectUri,
-      cacheLocation: "localStorage"
+      cacheLocation: "localStorage", 
+      instance: opts.instance
     });
+    this._ctx
     this._env = opts.environment || Environment.AzureCloud;
     this._resource = opts.resource || this._env.resourceManagerEndpointUrl;
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -105,10 +105,9 @@ export class AuthManager {
       clientId: opts.clientId,
       tenant: opts.tenant,
       redirectUri: opts.redirectUri,
-      cacheLocation: "localStorage", 
+      cacheLocation: "localStorage",
       instance: opts.instance
     });
-    this._ctx
     this._env = opts.environment || Environment.AzureCloud;
     this._resource = opts.resource || this._env.resourceManagerEndpointUrl;
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-browserauth"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Browser-specific authentication library for Azure services",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
Allow users to set the URL of the AAD endpoint URL. 

In cases where the library may want to be used in other Azure clouds, the developer does not only set the Environment but will need to also set the instance URL to a appropriate endpoint. 

For example when targeting Azure Gov, the endpoint is `http://login.microsoftonline.us/`. 