### PR TITLE
Update dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 1.0.0 - 2020-05-27
+Updating `@azure/ms-rest-azure-env` and `@azure/ms-rest-js` dependencies to allow authentication in the browsers for the Azure SDKs that have moved on to using v2 of `@azure/ms-rest-js`.
+[PR 30](https://github.com/Azure/ms-rest-browserauth/pull/30)
+
 ## 0.1.5 - 2020-04-21
 Allow `popUp`(boolean) option to be passed to the AuthManager. Setting this option to true enables login through a popup window instead of a full redirect. The default value is `false`.
 [PR 28](https://github.com/Azure/ms-rest-browserauth/pull/28)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-browserauth"
   },
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "Browser-specific authentication library for Azure services",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@azure/ms-rest-azure-env": "^1.1.0",
-    "@azure/ms-rest-js": "^1.8.1",
+    "@azure/ms-rest-azure-env": "^2.0.0",
+    "@azure/ms-rest-js": "^2.0.4",
     "adal-angular": "^1.0.17",
     "tslib": "^1.9.3"
   },


### PR DESCRIPTION
Issue - #29 

Azure SDKs have moved on to using `@azure/ms-rest-js` v2, whereas the `@azure/ms-rest-browserauth` still depends on v1, this PR attempts to update the dependencies to allow the library to work with the newer Azure SDKs.

Tested the new library with both the react app samples, everything worked fine.